### PR TITLE
Create prior-art directory

### DIFF
--- a/prior-art/Survey2021.hs
+++ b/prior-art/Survey2021.hs
@@ -1,0 +1,1064 @@
+module HW.Template.Survey2021
+  ( callToAction
+  , template
+  )
+where
+
+import qualified Control.Monad as Monad
+import qualified Data.String as String
+import qualified Data.Text as Text
+import qualified HW.Template.Base as Base
+import qualified HW.Type.BaseUrl as BaseUrl
+import qualified HW.Type.Number as Number
+import qualified HW.Type.Route as Route
+import qualified Lucid as Html
+import qualified Lucid as H
+
+template :: BaseUrl.BaseUrl -> Html.Html ()
+template baseUrl =
+  Base.template baseUrl "2021 Survey :: Haskell Weekly" mempty $ do
+    Html.h2_ [Html.class_ "f2 mv3 tracked-tight"] "2021 Survey"
+    H.div_ $ do
+      H.p_ $ do
+        "Welcome to the 2021 State of Haskell Survey! "
+        "This survey opens on November 1st and closes on the 15th. "
+        "After the survey closes, anonymized survey results will be made publicly available under the "
+        H.a_
+          [H.href_ "https://opendatacommons.org/licenses/odbl/"]
+          "Open Database License"
+        "."
+      H.p_ $ do
+        "The goal of this survey is to better understand what people think of the Haskell programming language, together with its ecosystem and community. "
+        "Whether you have never used Haskell or you use it every day, we want to hear from you!"
+      H.p_ $ do
+        "Every question is optional. "
+        "If you do not feel comfortable answering a question, skip it! "
+        "The survey may look long, but most people fill it out in just a few minutes. "
+        "Thank you for giving us your feedback!"
+      H.form_ [H.class_ "dn", H.id_ "survey", H.method_ "post"] $ do
+        H.input_
+          [ H.id_ "started-at"
+          , H.name_ "started-at"
+          , H.type_ "hidden"
+          ]
+        H.input_
+          [ H.id_ "finished-at"
+          , H.name_ "finished-at"
+          , H.type_ "hidden"
+          ]
+        renderSections sections
+        H.input_
+          [ H.class_ "b bn bg-dark-blue input-reset pa3 pointer white"
+          , H.type_ "submit"
+          , H.value_ "Submit"
+          ]
+    H.noscript_ . H.p_ $ do
+      "JavaScript is required to fill out this survey. "
+      "Please enable JavaScript to continue."
+    H.script_
+      "(function () {\
+        \document.querySelector('#survey').classList.remove('dn');\
+        \document.querySelector('#started-at').value = new Date().toISOString();\
+        \document.querySelector('#survey').addEventListener('submit', function () {\
+          \document.querySelector('#finished-at').value = new Date().toISOString();\
+        \});\
+        \document.querySelector('#survey').addEventListener('input', function (event) {\
+          \document.querySelector('#' + event.target.name + '-time').value = performance.now();\
+        \});\
+      \}());"
+
+sections :: [(Int, Section)]
+sections = withIndex
+  [ haskellUsageSection
+  , projectsSection
+  , compilersSection
+  , toolingSection
+  , infrastructureSection
+  , communitySection
+  , feelingsSection
+  , demographicsSection
+  , metaSection
+  , freeResponseSection
+  ]
+
+withIndex :: [a] -> [(Int, a)]
+withIndex = zip [0 ..]
+
+haskellUsageSection :: Section
+haskellUsageSection = makeSection
+  "Haskell usage"
+  [ Question "What is your email address?" Email
+  , Question "Do you use Haskell?" $ SingleResponse
+    [ "Yes"
+    , "No, but I used to"
+    , "No, I never have"
+    ]
+  , Question "If you stopped using Haskell, how long did you use it before you stopped?" $ SingleResponse
+    [ "Less than 1 day"
+    , "1 day to 1 week"
+    , "1 week to 1 month"
+    , "1 month to 1 year"
+    , "More than 1 year"
+    ]
+  , Question "If you do not use Haskell, why not?" $ MultiResponse AllowOther
+    [ "Haskell does not support the platforms I need"
+    , "Haskell is too hard to learn"
+    , "Haskell lacks critical features"
+    , "Haskell lacks critical libraries"
+    , "Haskell lacks critical tools"
+    , "Haskell's documentation is not good enough"
+    , "Haskell's performance is not good enough"
+    , "My company doesn't use Haskell"
+    ]
+  , Question "How many years have you been using Haskell?" $ SingleResponse
+    [ "Less than 1"
+    , "1 to 2"
+    , "2 to 3"
+    , "3 to 4"
+    , "4 to 5"
+    , "5 to 6"
+    , "6 to 7"
+    , "7 to 8"
+    , "8 to 9"
+    , "9 to 10"
+    , "10 to 11"
+    , "11 to 12"
+    , "12 to 13"
+    , "13 to 14"
+    , "14 to 15"
+    , "More than 15"
+    ]
+  , Question "How frequently do you use Haskell?" $ SingleResponse
+    [ "Daily"
+    , "Weekly"
+    , "Monthly"
+    , "Yearly"
+    , "Rarely"
+    ]
+  , Question "How would you rate your proficiency in Haskell?" $ SingleResponse
+    [ "I can't write or read Haskell"
+    , "I can write simple programs in Haskell"
+    , "I can write useful, production-ready code but it is a struggle"
+    , "I am productive writing Haskell"
+    , "I'm an expert"
+    ]
+  , Question "Where do you use Haskell?" $ MultiResponse RejectOther
+    [ "Academia"
+    , "Home"
+    , "Industry"
+    , "School"
+    ]
+  , Question "Do you use Haskell at work?" $ SingleResponse
+    [ "Yes, most of the time"
+    , "Yes, some of the time"
+    , "No, but my company does"
+    , "No, but I'd like to"
+    , "No, and I don't want to"
+    ]
+  , Question "If you do not use Haskell at work, why not?" $ MultiResponse AllowOther
+    [ "Haskell does not support the platforms I need"
+    , "Haskell is too hard to learn"
+    , "Haskell lacks critical features"
+    , "Haskell lacks critical libraries"
+    , "Haskell lacks critical tools"
+    , "Haskell's documentation is not good enough"
+    , "Haskell's performance is not good enough"
+    , "It's too hard to hire Haskell developers"
+    , "My company doesn't use Haskell"
+    ]
+  , Question "Which programming languages other than Haskell are you fluent in?" $ MultiResponse AllowOther
+    [ "Assembly"
+    , "C"
+    , "C#"
+    , "C++"
+    , "Clojure"
+    , "Elm"
+    , "Erlang"
+    , "F#"
+    , "Go"
+    , "Java"
+    , "JavaScript"
+    , "Kotlin"
+    , "Lua"
+    , "Matlab"
+    , "Ocaml"
+    , "Perl"
+    , "PHP"
+    , "PureScript"
+    , "Python"
+    , "R"
+    , "Ruby"
+    , "Rust"
+    , "Scala"
+    , "Shell"
+    , "Swift"
+    , "TypeScript"
+    ]
+  , Question "Which types of software do you develop with Haskell?" $ MultiResponse AllowOther
+    [ "Agents or daemons"
+    , "API services (returning non-HTML)"
+    , "Automation or scripts"
+    , "Command-line programs (CLI)"
+    , "Data processing"
+    , "Desktop programs (GUI)"
+    , "Libraries or frameworks"
+    , "Web services (returning HTML)"
+    ]
+  , Question "Which industries do you use Haskell in?" $ MultiResponse AllowOther
+    [ "Academia"
+    , "Banking or finance"
+    , "Commerce or retail"
+    , "Cryptocurrency"
+    , "Education"
+    , "Embedded"
+    , "Gaming"
+    , "Government"
+    , "Healthcare or medical"
+    , "Mobile"
+    , "Science"
+    , "Web"
+    ]
+  ]
+
+projectsSection :: Section
+projectsSection = makeSection
+  "Projects"
+  [ Question "How many Haskell projects do you contribute to?" $ SingleResponse
+    [ "0"
+    , "1"
+    , "2"
+    , "3"
+    , "4"
+    , "5"
+    , "6 to 10"
+    , "11 to 20"
+    , "More than 20"
+    ]
+  , Question "What is the total size of all the Haskell projects you contribute to?" $ SingleResponse
+    [ "Less than 1,000 lines of code"
+    , "Between 1,000 and 9,999 lines of code"
+    , "Between 10,000 and 99,999 lines of code"
+    , "More than 100,000 lines of code"
+    ]
+  , Question "Which platforms do you develop Haskell on?" $ MultiResponse AllowOther
+    [ "BSD"
+    , "Linux"
+    , "MacOS"
+    , "Windows"
+    ]
+  , Question "Which platforms do you target?" $ MultiResponse AllowOther
+    [ "Android"
+    , "BSD"
+    , "iOS"
+    , "Linux"
+    , "MacOS"
+    , "Windows"
+    ]
+  ]
+
+compilersSection :: Section
+compilersSection = makeSection
+  "Compilers"
+  [ Question "Which Haskell compilers do you use?" $ MultiResponse AllowOther
+    [ "GHC"
+    , "GHCJS"
+    ]
+  , Question "Which installation methods do you use for your Haskell compiler?" $ MultiResponse AllowOther
+    [ "Source"
+    , "Official binaries"
+    , "Haskell Platform"
+    , "Operating system package"
+    , "Stack"
+    , "Nix"
+    , "ghcup"
+    , "Chocolatey"
+    , "Homebrew"
+    ]
+  , Question "Has upgrading your Haskell compiler broken your code in the last year?" $ SingleResponse
+    [ "Yes"
+    , "No"
+    ]
+  , Question "How has upgrading your Haskell compiler broken your code in the last year?" $ MultiResponse AllowOther
+    [ "Compiler bugs"
+    , "Expected changes, such as the MonadFail proposal"
+    , "Incompatible dependencies"
+    , "New warnings"
+    , "Unexpected changes"
+    ]
+  , Question "Which versions of GHC do you use?" $ MultiResponse RejectOther
+    [ "> 9.2"
+    , "9.2"
+    , "9.0"
+    , "8.10.x"
+    , "8.8.x"
+    , "8.6.x"
+    , "8.4.x"
+    , "8.2.x"
+    , "< 8.2"
+    ]
+  , Question "Which language extensions would you like to be enabled by default?" $ ExtensionResponse
+    [ "AllowAmbiguousTypes"
+    , "ApplicativeDo"
+    , "Arrows"
+    , "BangPatterns"
+    , "BinaryLiterals"
+    , "BlockArguments"
+    , "CApiFFI"
+    , "ConstrainedClassMethods"
+    , "ConstraintKinds"
+    , "Cpp"
+    , "DataKinds"
+    , "DatatypeContexts"
+    , "DefaultSignatures"
+    , "DeriveAnyClass"
+    , "DeriveDataTypeable"
+    , "DeriveFoldable"
+    , "DeriveFunctor"
+    , "DeriveGeneric"
+    , "DeriveLift"
+    , "DeriveTraversable"
+    , "DerivingStrategies"
+    , "DerivingVia"
+    , "DisambiguateRecordFields"
+    , "DuplicateRecordFields"
+    , "EmptyCase"
+    , "ExistentialQuantification"
+    , "ExplicitForAll"
+    , "ExplicitNamespaces"
+    , "ExtendedDefaultRules"
+    , "FlexibleContexts"
+    , "FlexibleInstances"
+    , "ForeignFunctionInterface"
+    , "FunctionalDependencies"
+    , "GADTs"
+    , "GADTSyntax"
+    , "GeneralizedNewtypeDeriving"
+    , "HexFloatLiterals"
+    , "ImplicitParams"
+    , "ImportQualifiedPost"
+    , "ImpredicativeTypes"
+    , "IncoherentInstances"
+    , "InstanceSigs"
+    , "InterruptibleFFI"
+    , "KindSignatures"
+    , "LambdaCase"
+    , "LiberalTypeSynonyms"
+    , "LinearTypes"
+    , "MagicHash"
+    , "MonadComprehensions"
+    , "MonoLocalBinds"
+    , "MultiParamTypeClasses"
+    , "MultiWayIf"
+    , "NamedFieldPuns"
+    , "NamedWildCards"
+    , "NegativeLiterals"
+    , "NoEmptyDataDecls"
+    , "NoFieldSelectors"
+    , "NoImplicitPrelude"
+    , "NoMonadFailDesugaring"
+    , "NoMonomorphismRestriction"
+    , "NoPatternGuards"
+    , "NoStarIsType"
+    , "NoTraditionalRecordSyntax"
+    , "NPlusKPatterns"
+    , "NullaryTypeClasses"
+    , "NumDecimals"
+    , "NumericUnderscores"
+    , "OverlappingInstances"
+    , "OverloadedLabels"
+    , "OverloadedLists"
+    , "OverloadedRecordDot"
+    , "OverloadedRecordUpdate"
+    , "OverloadedStrings"
+    , "PackageImports"
+    , "ParallelListComp"
+    , "PartialTypeSignatures"
+    , "PatternSynonyms"
+    , "PolyKinds"
+    , "PostfixOperators"
+    , "QuantifiedConstraints"
+    , "QuasiQuotes"
+    , "Rank2Types"
+    , "RankNTypes"
+    , "RebindableSyntax"
+    , "RecordWildCards"
+    , "RecursiveDo"
+    , "RoleAnnotations"
+    , "ScopedTypeVariables"
+    , "StandaloneDeriving"
+    , "StandaloneKindSignatures"
+    , "StaticPointers"
+    , "Strict"
+    , "StrictData"
+    , "TemplateHaskell"
+    , "TemplateHaskellQuotes"
+    , "TransformListComp"
+    , "Trustworthy"
+    , "TupleSections"
+    , "TypeApplications"
+    , "TypeFamilies"
+    , "TypeFamilyDependencies"
+    , "TypeInType"
+    , "TypeOperators"
+    , "TypeSynonymInstances"
+    , "UnboxedSums"
+    , "UnboxedTuples"
+    , "UndecidableInstances"
+    , "UndecidableSuperClasses"
+    , "UnicodeSyntax"
+    , "UnliftedDatatypes"
+    , "UnliftedNewtypes"
+    , "Unsafe"
+    , "ViewPatterns"
+    ]
+  , Question "How important do you feel it would be to have a new version of the Haskell language standard?" $ SingleResponse
+    [ "Extremely important"
+    , "Very important"
+    , "Moderately important"
+    , "Slightly important"
+    , "Not at all important"
+    ]
+  ]
+
+toolingSection :: Section
+toolingSection = makeSection
+  "Tooling"
+  [ Question "Which build tools do you use for Haskell?" $ MultiResponse AllowOther
+    [ "Bazel"
+    , "Cabal"
+    , "ghc-pkg"
+    , "haskell.nix"
+    , "Make"
+    , "Nix"
+    , "Shake"
+    , "Stack"
+    ]
+  , Question "Which editors do you use for Haskell?" $ MultiResponse AllowOther
+    [ "Atom"
+    , "Emacs family"
+    , "IntelliJ IDEA"
+    , "Sublime Text"
+    , "Vi family"
+    , "Visual Studio Code"
+    ]
+  , Question "Which IDEs do you use for Haskell?" $ MultiResponse AllowOther
+    [ "IntelliJ"
+    , "Intero"
+    , "ghcid"
+    , "ghcide"
+    , "Haskell Language Server (HLS)"
+    ]
+  , Question "Which version control systems do you use for Haskell?" $ MultiResponse AllowOther
+    [ "Darcs"
+    , "Git"
+    , "Mercurial"
+    ]
+  , Question "Where do you get Haskell packages from?" $ MultiResponse AllowOther
+    [ "Hackage"
+    , "Nix"
+    , "Source"
+    , "Stackage"
+    ]
+  , Question "Which tools do you use to test Haskell code?" $ MultiResponse AllowOther
+    [ "Haskell Test Framework"
+    , "Hedgehog"
+    , "Hspec"
+    , "HUnit"
+    , "QuickCheck"
+    , "SmallCheck"
+    , "Tasty"
+    ]
+  , Question "Which tools do you use to benchmark Haskell code?" $ MultiResponse AllowOther
+    [ "Bench"
+    , "Criterion"
+    , "Gauge"
+    ]
+  ]
+
+infrastructureSection :: Section
+infrastructureSection = makeSection
+  "Infrastructure"
+  [ Question "Which tools do you use to deploy Haskell applications?" $ MultiResponse AllowOther
+    [ "Docker images"
+    , "Dynamic binaries"
+    , "Nix expressions"
+    , "Static binaries"
+    ]
+  , Question "Where do you deploy Haskell applications?" $ MultiResponse AllowOther
+    [ "Amazon Web Services"
+    , "Digital Ocean"
+    , "Google Cloud"
+    , "Heroku"
+    , "Microsoft Azure"
+    , "Self or company owned servers"
+    ]
+  ]
+
+communitySection :: Section
+communitySection = makeSection
+  "Community"
+  [ Question "Where do you interact with the Haskell community?" $ MultiResponse AllowOther
+    [ "Conferences (academic)"
+    , "Conferences (commercial)"
+    , "Discord"
+    , "Discourse"
+    , "GitHub"
+    , "Gitter"
+    , "IRC"
+    , "Lobsters"
+    , "Mailing lists"
+    , "Mastodon"
+    , "Matrix/Riot"
+    , "Meetups"
+    , "Reddit"
+    , "Slack"
+    , "Stack Overflow"
+    , "Telegram"
+    , "Twitter"
+    , "Zulip"
+    ]
+  , Question "Which of the following Haskell topics would you like to see more written about?" $ MultiResponse AllowOther
+    [ "Algorithm implementations"
+    , "Application architectures"
+    , "Beginner fundamentals"
+    , "Best practices"
+    , "Case studies"
+    , "Comparisons to other languages"
+    , "Debugging how-tos"
+    , "Design patterns"
+    , "Game development"
+    , "GUIs"
+    , "Library walkthroughs"
+    , "Machine learning"
+    , "Mobile development"
+    , "Performance analysis"
+    , "Production infrastructure"
+    , "Project maintenance"
+    , "Project setup"
+    , "Testing"
+    , "Tooling choices"
+    , "Web development"
+    ]
+  ]
+
+feelingsSection :: Section
+feelingsSection = makeSection
+  "Feelings"
+  [ likert "I feel welcome in the Haskell community."
+  , likert "I am satisfied with Haskell as a language."
+  , likert "I am satisfied with Haskell's compilers, such as GHC."
+  , likert "I am satisfied with Haskell's build tools, such as Cabal."
+  , likert "I am satisfied with Haskell's package repositories, such as Hackage."
+  , likert "I can find Haskell libraries for the things that I need."
+  , likert "I think Haskell libraries are high quality."
+  , likert "I have a good understanding of Haskell best practices."
+  , likert "I think Haskell libraries are well documented."
+  , likert "I can easily compare competing Haskell libraries to select the best one."
+  , likert "I think that Haskell libraries are easy to use."
+  , likert "I think that Haskell libraries provide a stable API."
+  , likert "I think that Haskell libraries work well together."
+  , likert "I think that software written in Haskell is easy to maintain."
+  , likert "Once my Haskell program compiles, it generally does what I intended."
+  , likert "I think that Haskell libraries perform well."
+  , likert "Haskell's performance meets my needs."
+  , likert "I can easily reason about the performance of my Haskell code."
+  , likert "I would recommend using Haskell to others."
+  , likert "I would prefer to use Haskell for my next new project."
+  , likert "Haskell is working well for my team."
+  , likert "Haskell is critical to my company's success."
+  , likert "As a candidate, I can easily find Haskell jobs."
+  , likert "As a hiring manager, I can easily find qualified Haskell candidates."
+  ]
+
+demographicsSection :: Section
+demographicsSection = makeSection
+  "Demographics"
+  [ Question "Which country do you live in?" $ SingleResponse
+    [ "Afghanistan"
+    , "Akrotiri"
+    , "Albania"
+    , "Algeria"
+    , "American Samoa"
+    , "Andorra"
+    , "Angola"
+    , "Anguilla"
+    , "Antarctica"
+    , "Antigua and Barbuda"
+    , "Argentina"
+    , "Armenia"
+    , "Aruba"
+    , "Ashmore and Cartier Islands"
+    , "Australia"
+    , "Austria"
+    , "Azerbaijan"
+    , "The Bahamas"
+    , "Bahrain"
+    , "Bangladesh"
+    , "Barbados"
+    , "Bassas da India"
+    , "Belarus"
+    , "Belgium"
+    , "Belize"
+    , "Benin"
+    , "Bermuda"
+    , "Bhutan"
+    , "Bolivia"
+    , "Bosnia and Herzegovina"
+    , "Botswana"
+    , "Bouvet Island"
+    , "Brazil"
+    , "British Indian Ocean Territory"
+    , "British Virgin Islands"
+    , "Brunei"
+    , "Bulgaria"
+    , "Burkina Faso"
+    , "Burma"
+    , "Burundi"
+    , "Cambodia"
+    , "Cameroon"
+    , "Canada"
+    , "Cape Verde"
+    , "Cayman Islands"
+    , "Central African Republic"
+    , "Chad"
+    , "Chile"
+    , "China"
+    , "Christmas Island"
+    , "Clipperton Island"
+    , "Cocos (Keeling) Islands"
+    , "Colombia"
+    , "Comoros"
+    , "Democratic Republic of the Congo"
+    , "Republic of the Congo"
+    , "Cook Islands"
+    , "Coral Sea Islands"
+    , "Costa Rica"
+    , "Cote d'Ivoire"
+    , "Croatia"
+    , "Cuba"
+    , "Cyprus"
+    , "Czech Republic"
+    , "Denmark"
+    , "Dhekelia"
+    , "Djibouti"
+    , "Dominica"
+    , "Dominican Republic"
+    , "Ecuador"
+    , "Egypt"
+    , "El Salvador"
+    , "Equatorial Guinea"
+    , "Eritrea"
+    , "Estonia"
+    , "Ethiopia"
+    , "Europa Island"
+    , "Falkland Islands (Islas Malvinas)"
+    , "Faroe Islands"
+    , "Fiji"
+    , "Finland"
+    , "France"
+    , "French Guiana"
+    , "French Polynesia"
+    , "French Southern and Antarctic Lands"
+    , "Gabon"
+    , "The Gambia"
+    , "Gaza Strip"
+    , "Georgia"
+    , "Germany"
+    , "Ghana"
+    , "Gibraltar"
+    , "Glorioso Islands"
+    , "Greece"
+    , "Greenland"
+    , "Grenada"
+    , "Guadeloupe"
+    , "Guam"
+    , "Guatemala"
+    , "Guernsey"
+    , "Guinea"
+    , "Guinea-Bissau"
+    , "Guyana"
+    , "Haiti"
+    , "Heard Island and McDonald Islands"
+    , "Holy See (Vatican City)"
+    , "Honduras"
+    , "Hong Kong"
+    , "Hungary"
+    , "Iceland"
+    , "India"
+    , "Indonesia"
+    , "Iran"
+    , "Iraq"
+    , "Ireland"
+    , "Isle of Man"
+    , "Israel"
+    , "Italy"
+    , "Jamaica"
+    , "Jan Mayen"
+    , "Japan"
+    , "Jersey"
+    , "Jordan"
+    , "Juan de Nova Island"
+    , "Kazakhstan"
+    , "Kenya"
+    , "Kiribati"
+    , "North Korea"
+    , "South Korea"
+    , "Kuwait"
+    , "Kyrgyzstan"
+    , "Laos"
+    , "Latvia"
+    , "Lebanon"
+    , "Lesotho"
+    , "Liberia"
+    , "Libya"
+    , "Liechtenstein"
+    , "Lithuania"
+    , "Luxembourg"
+    , "Macau"
+    , "Macedonia"
+    , "Madagascar"
+    , "Malawi"
+    , "Malaysia"
+    , "Maldives"
+    , "Mali"
+    , "Malta"
+    , "Marshall Islands"
+    , "Martinique"
+    , "Mauritania"
+    , "Mauritius"
+    , "Mayotte"
+    , "Mexico"
+    , "Federated States of Micronesia"
+    , "Moldova"
+    , "Monaco"
+    , "Mongolia"
+    , "Montserrat"
+    , "Morocco"
+    , "Mozambique"
+    , "Namibia"
+    , "Nauru"
+    , "Navassa Island"
+    , "Nepal"
+    , "Netherlands"
+    , "Netherlands Antilles"
+    , "New Caledonia"
+    , "New Zealand"
+    , "Nicaragua"
+    , "Niger"
+    , "Nigeria"
+    , "Niue"
+    , "Norfolk Island"
+    , "Northern Mariana Islands"
+    , "Norway"
+    , "Oman"
+    , "Pakistan"
+    , "Palau"
+    , "Palestine"
+    , "Panama"
+    , "Papua New Guinea"
+    , "Paracel Islands"
+    , "Paraguay"
+    , "Peru"
+    , "Philippines"
+    , "Pitcairn Islands"
+    , "Poland"
+    , "Portugal"
+    , "Puerto Rico"
+    , "Qatar"
+    , "Reunion"
+    , "Romania"
+    , "Russia"
+    , "Rwanda"
+    , "Saint Helena"
+    , "Saint Kitts and Nevis"
+    , "Saint Lucia"
+    , "Saint Pierre and Miquelon"
+    , "Saint Vincent and the Grenadines"
+    , "Samoa"
+    , "San Marino"
+    , "Sao Tome and Principe"
+    , "Saudi Arabia"
+    , "Senegal"
+    , "Serbia and Montenegro"
+    , "Seychelles"
+    , "Sierra Leone"
+    , "Singapore"
+    , "Slovakia"
+    , "Slovenia"
+    , "Solomon Islands"
+    , "Somalia"
+    , "South Africa"
+    , "South Georgia and the South Sandwich Islands"
+    , "Spain"
+    , "Spratly Islands"
+    , "Sri Lanka"
+    , "Sudan"
+    , "Suriname"
+    , "Svalbard"
+    , "Swaziland"
+    , "Sweden"
+    , "Switzerland"
+    , "Syria"
+    , "Taiwan"
+    , "Tajikistan"
+    , "Tanzania"
+    , "Thailand"
+    , "Timor-Leste"
+    , "Togo"
+    , "Tokelau"
+    , "Tonga"
+    , "Trinidad and Tobago"
+    , "Tromelin Island"
+    , "Tunisia"
+    , "Turkey"
+    , "Turkmenistan"
+    , "Turks and Caicos Islands"
+    , "Tuvalu"
+    , "Uganda"
+    , "Ukraine"
+    , "United Arab Emirates"
+    , "United Kingdom"
+    , "United States"
+    , "Uruguay"
+    , "Uzbekistan"
+    , "Vanuatu"
+    , "Venezuela"
+    , "Vietnam"
+    , "Virgin Islands"
+    , "Wake Island"
+    , "Wallis and Futuna"
+    , "West Bank"
+    , "Western Sahara"
+    , "Yemen"
+    , "Zambia"
+    , "Zimbabwe"
+    ]
+  , Question "Do you consider yourself a member of an underrepresented or marginalized group in technology?" $ MultiResponse AllowOther
+    [ "Yes, but I prefer not to say which"
+    , "Cultural beliefs"
+    , "Disabled or person with disability (including physical, mental, and other)"
+    , "Educational background"
+    , "Language"
+    , "Lesbian, gay, bisexual, queer or otherwise non-heterosexual"
+    , "Non-binary gender"
+    , "Older or younger than the average developers I know"
+    , "Political beliefs"
+    , "Racial or ethnic minority"
+    , "Religious beliefs"
+    , "Trans"
+    , "Woman or perceived as a woman"
+    ]
+  , Question "Do you feel your belonging to an underrepresented or marginalized group in technology makes it difficult for you to participate in the Haskell community?" $ SingleResponse
+    [ "Often"
+    , "Sometimes"
+    , "Never"
+    ]
+  , Question "Are you a student?" $ SingleResponse
+    [ "Yes, full time"
+    , "Yes, part time"
+    , "No"
+    ]
+  , Question "What is the highest level of education you have completed?" $ SingleResponse
+    [ "Less than high school diploma"
+    , "High school diploma"
+    , "Some college"
+    , "Associate degree"
+    , "Bachelor's degree"
+    , "Master's degree"
+    , "Professional degree"
+    , "Doctoral degree"
+    ]
+  , Question "What is your employment status?" $ SingleResponse
+    [ "Employed full time"
+    , "Employed part time"
+    , "Self employed"
+    , "Not employed, but looking for work"
+    , "Not employed, and not looking for work"
+    , "Retired"
+    ]
+  , Question "How large is the company you work for?" $ SingleResponse
+    [ "Fewer than 10 employees"
+    , "10 to 99 employees"
+    , "100 to 999 employees"
+    , "More than 1,000 employees"
+    ]
+  , Question "How many years have you been coding?" $ SingleResponse
+    [ "0 to 4 years"
+    , "5 to 9 years"
+    , "10 to 14 years"
+    , "15 to 19 years"
+    , "20 to 24 years"
+    , "25 to 29 years"
+    , "30 or more years"
+    ]
+  , Question "How many years have you been coding professionally?" $ SingleResponse
+    [ "0 to 4 years"
+    , "5 to 9 years"
+    , "10 to 14 years"
+    , "15 to 19 years"
+    , "20 to 24 years"
+    , "25 to 29 years"
+    , "30 or more years"
+    ]
+  , Question "Do you code as a hobby?" $ SingleResponse
+    [ "Yes"
+    , "No"
+    ]
+  , Question "Have you contributed to any open source projects?" $ SingleResponse
+    [ "Yes"
+    , "No"
+    ]
+  ]
+
+metaSection :: Section
+metaSection = makeSection
+  "Meta"
+  [ Question "Did you take any previous surveys?" $ MultiResponse RejectOther
+    [ "2020"
+    , "2019"
+    , "2018"
+    , "2017"
+    ]
+  , Question "How did you hear about this survey?" $ MultiResponse AllowOther
+    [ "Discord"
+    , "Discourse"
+    , "GitHub"
+    , "Haskell Weekly"
+    , "Gitter"
+    , "In person"
+    , "IRC"
+    , "Lobsters"
+    , "Mailing lists"
+    , "Mastodon"
+    , "Matrix/Riot"
+    , "Reddit"
+    , "Slack"
+    , "Telegram"
+    , "Twitter"
+    , "Zulip"
+    ]
+  ]
+
+freeResponseSection :: Section
+freeResponseSection = makeSection
+  "Free response"
+  [ Question "If you wanted to convince someone to use Haskell, what would you say?" FreeResponse
+  , Question "If you could change one thing about Haskell, what would it be?" FreeResponse
+  ]
+
+data Section =
+  Section
+  { sectionTitle :: Text.Text
+  , sectionQuestions :: [(Int, Question)]
+  }
+  deriving (Eq, Show)
+
+makeSection :: Text.Text -> [Question] -> Section
+makeSection title = Section title . withIndex
+
+data Question =
+  Question
+  { questionPrompt :: Text.Text
+  , questionResponse :: Response
+  }
+  deriving (Eq, Show)
+
+data Response
+  = Email
+  | SingleResponse [Text.Text]
+  | MultiResponse Other [Text.Text]
+  | ExtensionResponse [Text.Text]
+  | FreeResponse
+  deriving (Eq, Show)
+
+likert :: Text.Text -> Question
+likert prompt = Question prompt $ SingleResponse
+  ["Strongly disagree", "Disagree", "Neutral", "Agree", " Strongly agree"]
+
+data Other
+  = AllowOther
+  | RejectOther
+  deriving (Eq, Show)
+
+renderSections :: [(Int, Section)] -> H.Html ()
+renderSections = mapM_ renderSection
+
+renderSection :: (Int, Section) -> H.Html ()
+renderSection (s, section) = do
+  H.h3_ [H.class_ "f3 mv3 tracked-tight", H.id_ $ "section-" <> genericShow s] . H.toHtml $ sectionTitle section
+  renderQuestions s $ sectionQuestions section
+
+renderQuestions :: Int -> [(Int, Question)] -> H.Html ()
+renderQuestions s = H.ol_ [H.class_ "pl3"] . mapM_ (renderQuestion s)
+
+genericShow :: (Show a, String.IsString string) => a -> string
+genericShow = String.fromString . show
+
+renderQuestion :: Int -> (Int, Question) -> H.Html ()
+renderQuestion s (q, question) = H.li_ [H.id_ $ "section-" <> genericShow s <> "-question-" <> genericShow q] $ do
+  H.p_ $ do
+    H.strong_ . H.toHtml $ questionPrompt question
+    " (optional)"
+    case questionResponse question of
+      Email -> do
+        " "
+        "This will not sign you up for anything. "
+        "We will never share your email address with anyone. "
+        "We may use your email address to follow up on survey responses."
+      _ -> pure ()
+  let name = Text.concat ["section-", genericShow s, "-question-", genericShow q]
+  H.input_ [H.name_ $ name <> "-prompt", H.type_ "hidden", H.value_ $ questionPrompt question]
+  case questionResponse question of
+    Email -> H.div_ $ do
+      H.input_
+        [H.name_ name
+        , H.placeholder_ "you@example.com"
+        , H.type_ "email"
+        ]
+    SingleResponse choices -> do
+      Monad.forM_ choices $ \choice -> H.div_ . H.label_ [H.class_ "pointer"] $ do
+        H.input_ [H.class_ "pointer", H.name_ name, H.type_ "radio", H.value_ choice]
+        " "
+        H.toHtml choice
+      H.div_ . H.label_ [H.class_ "pointer"] $ do
+        H.input_ [H.checked_, H.class_ "pointer", H.name_ name, H.type_ "radio", H.value_ "n/a"]
+        " n/a"
+    MultiResponse other choices -> do
+      Monad.forM_ choices $ \choice -> H.div_ . H.label_ [H.class_ "pointer"] $ do
+        H.input_ [H.class_ "pointer", H.name_ name, H.type_ "checkbox", H.value_ choice]
+        " "
+        H.toHtml choice
+      case other of
+        RejectOther -> pure ()
+        AllowOther -> H.div_ . H.label_ [H.class_ "pointer"] $ do
+          "Other: "
+          H.input_ [H.name_ name]
+    ExtensionResponse choices -> do
+      Monad.forM_ (withIndex choices) $ \(c, choice) -> H.div_ $ do
+        let n = name <> "-choice-" <> genericShow c
+        H.input_ [H.name_ $ n <> "-value", H.type_ "hidden", H.value_ choice]
+        H.label_ [H.class_ "ba bg-washed-red ph1 pointer red"] $ do
+          "No "
+          H.input_ [H.class_ "pointer", H.name_ n, H.type_ "radio", H.value_ "no"]
+        H.input_ [H.checked_, H.class_ "mh1 pointer", H.name_ n, H.type_ "radio", H.value_ ""]
+        H.label_ [H.class_ "ba bg-washed-green green ph1 pointer"] $ do
+          H.input_ [H.class_ "pointer", H.name_ n, H.type_ "radio", H.value_ "yes"]
+          " Yes"
+        " "
+        H.toHtml choice
+        let t = n <> "-time"
+        H.input_ [H.id_ t, H.name_ t, H.type_ "hidden"]
+    FreeResponse -> H.textarea_ [H.class_ "db h4 mv3 w-100", H.name_ name] ""
+  let t = name <> "-time"
+  H.input_ [H.id_ t, H.name_ t, H.type_ "hidden"]
+
+callToAction :: BaseUrl.BaseUrl -> Html.Html ()
+callToAction baseUrl = case Number.fromNatural 2021 of
+  Left _ -> pure ()
+  Right year -> Html.div_
+    [ Html.class_ "ba b--green bg-washed-green center mw6 pa3 tc"
+    ] . Html.p_ [Html.class_ "mv0"] $ do
+      "Please take a few minutes to fill out the "
+      Html.a_ [Html.href_ . Route.toText baseUrl $ Route.Survey year] $ do
+        "2021 State of Haskell Survey"
+      ". Thanks, and be sure to tell your friends!"

--- a/prior-art/rust-2021.md
+++ b/prior-art/rust-2021.md
@@ -1,0 +1,1159 @@
+# Survey questions
+
+Whether or not you use Rust Programming Language <https://rust-lang.org> today, we want to hear from you!
+
+The Rust Community Team has created this survey to help us gauge how we're doing, what can be improved, and how we can best engage with all of you as we move forward.
+
+This is your chance to have a say in the development priorities for Rust.
+
+Unless you choose to enter your email, your answers will be anonymous. Any personal data you submit as a part of this survey will be handled in accordance with our policy as described in our Frequently Asked Questions:
+
+https://github.com/rust-community/team/wiki/State-of-the-Rust-Language-Community-Survey-FAQ
+
+We estimate it will take about 10-25 minutes to complete.
+
+## Rust Usage
+
+### Do you use Rust?
+
+Type: select one
+
+- Yes, I use Rust (for any purpose, even if you're just learning) [`NEXT`](#your-rust-experience)
+- No, I don't currently use Rust, but I have in the past [`NEXT`](#for-previous-rust-users)
+- No, I have never used Rust [`NEXT`](#for-non-rust-users)
+
+> **justification**
+>
+> Fundamental for cohort analysis
+
+## For previous Rust users
+
+### As you have indicated that you're no longer using Rust, what prompted you to participate in this survey?
+
+Type: select all that apply (optional)
+
+- I plan to return to using Rust in the future
+- I consider myself part of the Rust community
+- Specifically to provide feedback on why I stopped using Rust
+- To provide feedback on Rust in general
+- Curiosity
+- Other (open response)
+
+> **justification**
+>
+> Useful in understanding why non-users contribute;
+
+> **SURVEY FLOW**
+>
+> Skip to `## Your opinions about Rust` section
+
+## For non-Rust users
+
+### As you have indicated that you have not used Rust, what prompted you to participate in this survey?
+
+Type: select all that apply (optional)
+
+- I plan to use Rust in the future
+- I consider myself part of the Rust community
+- Specifically to provide feedback on WHY I do not use Rust
+- Curiosity
+- Other (open response)
+
+> **justification**
+>
+> Useful in understanding why non-users contribute to the survey
+
+> **SURVEY FLOW**
+>
+> Skip to `## Your opinions about Rust` section
+
+## Your Rust experience
+
+### On average, how often do you use Rust?
+
+Type: select one
+
+- Daily or nearly so
+- Weekly or nearly so
+- Monthly or nearly so
+- Rarely
+
+> **justification**
+>
+> This can be useful demographic information as a proxy for how "important" Rust is
+> in someone's technical life.
+>
+> We deliberately use calendar time for this question to gauge how "serious" the
+> programmer's use of Rust is. This does mean that we will group together, for example,
+> those who program once a week but always in Rust and those who program daily but
+> use Rust once a week.
+
+### How would you rate your Rust expertise?
+
+Type: select one
+
+- I can't read or write Rust
+- I can write simple programs in Rust
+- I can write useful, production-ready code but it is a struggle
+- I am productive writing Rust
+- I am an expert
+
+> **justification**
+>
+> Useful for cohort analysis, i.e., for other questions we can query if answers are significantly different for beginners vs advanced users.
+>
+> Previously this question was a 1-10 ranking. Having specific labels can help with consistency across responses. Additionally, having 10 choices
+> was too specific (i.e., what's the difference between a 7 and 8?) where as with the new answers, we have a better idea of what the differences 
+> between answers actually mean.
+
+### When did you learn to program in Rust?
+
+**Note**: while you may continue to try to improve your Rust skills, for this question assume "learning to program in Rust"
+means spending the *majority* of your time with Rust consuming learning materials or coding *in order to learn* (as opposed to achieving
+some other goal). If your learning process spans several of the listed time periods, pick the one where you felt you learned *the most*.
+
+Type: select one (optional)
+
+- I'm still *actively* trying to learn Rust
+- During 2021
+- During 2019 or 2020
+- During 2017 or 2018
+- During 2015 or 2016
+- During 2014 or before
+
+> **justification**
+>
+> Useful for cohort analysis, i.e., for other questions we can understand if *when* someone learned Rust impacts their views on things.
+>
+> The time periods used as answers try to reflect the major "epochs" of Rust history (i.e., pre-1.0, 2015 edition pre and post new error style,
+> and 2018 edition) as well as the most recent past. We use whole years even though this doesn't line up perfectly with these epochs. Learning
+> Rust in early 2015 was likely similar to the experience of learning Rust post 1.0 while before that the language was changing rapidly.
+> We explicitly use years instead of asking for which Rust edition someone learned because the former is often much easier for respondents to know.
+> It's also helpful to be more specific than an edition, and it's fairly easy to know which edition someone likely used based on the year they
+> learned Rust.
+
+### Which operating systems do you use regularly for Rust development?
+
+**Note**: this is specifically about which systems you use for development *not* all the 
+systems you target.
+
+Type: select all that apply (optional)
+
+- Linux
+- Windows
+- Windows Subsystem for Linux
+- Mac OS
+- Other (open response)
+
+> **justification**
+>
+> In general we'd like to know which operating systems are most used as dev machines in the community.
+>
+> We're using "Linux" here rather than grouping all UNIXes together, to allow
+> us to gauge interest in specific other UNIXes via the fill-in-the-blank
+> "other" option. If we grouped UNIXes together, users of other UNIX systems
+> wouldn't be visible; let's try to capture the level of interest in those
+> systems. As with many questions with an open "other" response; if any
+> specific answer appears frequently, we can add it to future surveys to reduce
+> the amount of work needed to process responses.
+
+### On the primary machine you compile Rust code on, how many CPUs are there?
+
+Please count *logical* CPUs here, not cores or sockets. You can get this number by running the following commands from the command line:
+
+- Linux: `nproc`
+- macOS: `sysctl -n hw.ncpu`
+- Windows Command Prompt: `echo %NUMBER_OF_PROCESSORS%`
+- Windows PowerShell: `(Get-CimInstance Win32_ComputerSystem).NumberOfLogicalProcessors`
+
+Type: free form (number, optional)
+
+> **justification**
+>
+> Question added by Josh Triplett. The answers can help tune parallel rustc:
+>
+> - When we encounter a scalability issue that starts at a certain number of CPUs, it'll be good to know what proportion of the Rust community is affected.
+> - It'll help when tuning algorithms or build systems whose memory usage may depend on the number of CPUs present.
+> - It'll help with prioritization around whether to make something go faster by throwing more CPUs at it or by optimizing on the same number of CPUs.
+> - It'll help avoid assumptions that rust developers might otherwise make about how universal the caliber of hardware they have is.
+
+### Which operating systems or runtimes do you develop Rust software for?
+
+**Note**: this is specifically about which operating system or runtime you **target** not which system you use
+for development nor which specific architectures (e.g., x86 vs ARM) you target.
+
+Type: select all that apply (optional)
+
+- Linux (desktop or server)
+- Windows
+- Mac OS
+- iOS
+- Android
+- Embedded platforms (with an operating system)
+- Embedded platforms (bare metal)
+- WebAssembly
+- Explicitly platform-independent (e.g., a library which does not interact with the operating system)
+- Other (open response)
+
+> **justification**
+>
+> This question can be used to figure out roughly what systems are being targeted as well as 
+> what OS stack is being developed against (i.e., desktop/server OS, mobile OS, embedded OS, bare metal)
+>
+> We're using "Linux" here rather than "*nix" or similar, with the same
+> justification as in the "Which operating systems do you use" question.
+>
+> We specifically care about the runtime environment being targeted. ISA and other machine specifics are
+> not what matters.
+
+### Which version(s) of Rust do you use for local development?
+
+Type: select all that apply (optional)
+
+- Current stable version
+- Previous stable version
+- A specific version of stable Rust equal to or newer than 1.47
+- A specific version of stable Rust older than 1.47
+- Beta release
+- Latest nightly
+- A specific version of nightly
+- Custom fork
+- I don't know
+- Other (open response)
+
+> **justification**
+>
+> Together with the following question, we can better determine what the spread of 
+> version usage is across the community.
+> We ask specifically about version 1.47 since it is, at the time of the survey, the 
+> version that was released ~1 year prior. Additionally, at the time of this writing
+> all major Linux distros have a version equal to or newer than this version.
+
+### Which version(s) of Rust do you use in automated testing (e.g., CI)?
+
+Type: select all that apply (optional)
+
+REPEAT
+
+> **justification**
+>
+> See the previous question.
+
+### If you use nightly, why?
+
+Type: select all that apply (optional)
+
+- I don't use nightly
+- Out of habit
+- For a particular language feature or set of language features I need
+- I like to have access to all the latest features
+- To help test the nightly version for bugs
+- For testing in CI
+- A crate dependency I use requires it
+- A tool I use requires it
+- Other (open response)
+
+> **justification**
+>
+> We'd like to know what are the common reasons people use nightly
+> so that we can better understand where testers are coming from.
+
+### If you use beta, why?
+
+Type: select all that apply (optional)
+
+- I don't use beta
+- Out of habit
+- To adopt stabilized language features as early as possible
+- To help test the beta version for bugs
+- For testing in CI
+- Other (open response)
+
+> **justification**
+>
+> Same justification as the question about nightly but for beta.
+
+### In which ways do you install Rust?
+
+Type: select all that apply (optional)
+
+- Rustup (where Rustup is installed from rust-lang.org or you built it from source)
+- Rustup (where Rustup is installed using any package manager)
+- Linux distribution package
+- Homebrew
+- Official rust-lang.org tarballs
+- Official Windows .msi installers
+- Official macOS .pkg installers
+- From source
+- Other (open response)
+
+> **justification**
+>
+> Since many of these sources are not under project control, it can be hard to know where
+> people are getting their Rust compiler from.
+
+### Which editor or IDE setup do you use with Rust code on a regular basis?
+
+Type: select all that apply (optional)
+
+- VS Code
+- vi/vim/neovim
+- IntelliJ/CLion/other Jet Brains IDE
+- Emacs
+- Sublime Text
+- Visual Studio
+- Xcode
+- Atom
+- Other (open response)
+
+> **justification**
+>
+> It is good to know which editor is the most preferred for Rust development. This
+> can change investment strategies for further IDE development.
+>
+> Note: previously this question included different 'drivers' of the Rust IDE
+> experience (e.g., racer, rls, rust-analyzer). Development has consolidated on
+> rust-analyzer, and so it's not necessary to find out which is being used.
+> If we are curious how far along adoption of rust-analyzer is, we can ask that
+> in a separate question, though this is likely easier to find out through download
+> numbers.
+
+### Which debuggers do you use for debugging Rust programs on a regular basis?
+
+Type: select all that apply (optional)
+
+- GDB
+- LLDB
+- Visual Studio
+- WinDBG
+- VS Code (using any debugger extension)
+- IntelliJ/CLion/other Jet Brains IDE
+- RR/Pernosco
+- 'println' debugging (or using any logging or tracing crate, etc.)
+- Other (open response)
+
+> **justification**
+>
+> It is good to know how many users use a debugging tool, and which tool they use.
+> This information could influence priorities for the compiler and tools teams.
+>
+> Note that there is some overlap between the answers, e.g., VS Code uses either a
+> GDB or LLDB plugin, but I think that is OK, we can take this into account when
+> interpreting the answers and we will get an indication of user's perceptions of
+> their tools.
+
+### Please indicate how vital to your workflow each of the following tools are when programming with Rust:
+
+Type: matrix (optional)
+
+Tools:
+
+- clippy
+- cargo
+- rustdoc/cargo doc
+- rustup
+- play.rust-lang.org
+- miri
+- rustfmt/cargo fmt
+- bindgen
+
+Rating:
+
+- Essential
+- Somewhat important
+- Not important
+- I have no experience with this tool
+
+> **justification**
+>
+> Understanding how important certain tools are to the community and *more importantly* to 
+> certain subsections of the community is important. This can also help us understand how
+> popular certain tools are as well as how important lesser used tools are to their users.
+
+### In which of the following ways have you participated in the Rust community in the last 6 months:
+
+Note that the following forms of participation do not include code related activities (i.e., writing, reviewing, or discussing code). Such pariticpation is asked about in later questions.
+
+Type: select all that apply (optional)
+
+- I have produced informational content about Rust (e.g., blogged, live streamed, made a YouTube video, presented at a conference/meetup, etc.)
+- On several occasions I have consumed informational content about Rust (e.g., blogs, live streams, YouTube videos, etc.)
+- On several occasions I have read comments about Rust content on "news" sites (e.g., Hacker News, reddit.com/r/rust, lobste.rs/t/rust, etc.)
+- On several occasions I have commented on Rust content on "news" sites (e.g., Hacker News, reddit.com/r/rust, lobste.rs/t/rust, etc.)
+- On several occasions I have read official Rust communication channels (e.g., This Week in Rust, the official Rust blog, the Rust Twitter account, etc.)
+- On several occasions I have participated in conversations about Rust on social media (Twitter, Facebook, LinkedIn, etc.)
+- I have participated in Rust community forums or chats (e.g., users.rust-lang.org, Rust Discord, a local Rust chat community, etc.)
+- I have attended a Rust meetup or conference (virtual or in-person)
+
+> **justification**
+>
+> We'd like to get a picture of _how_ people participate in the Rust community. In
+> particular we can use this information to do cohort analysis on highly "active"
+> community members in comparison to less active community members.
+
+### Roughly how often do you contribute to the Rust project?
+
+Type: matrix (optional)
+
+Activities:
+
+- Comment on, contribute to discussion of, or provide edits to an open RFC
+- Create a new thread or comment on internals.rust-lang.org
+- Discuss the Rust project in an official chat (either Zulip or Discord)
+- Open an issue on any repo in the rust-lang GitHub organization
+- Contribute code changes (including tests) to the Rust compiler (rust-lang/rust)
+- Contribute code changes (including tests) to any other project in the rust-lang GitHub organization
+- Contribute non-code changes (documentation, comments, etc.) to any project in the rust-lang GitHub organization
+
+Frequency:
+- More frequently than weekly
+- Weekly
+- Monthly
+- Less frequently than monthly
+- Never but have tried to
+- Never and have never tried to
+
+> **justification**
+>
+> We want to understand the nature of contribution to the Rust project both
+> to better understand the shape of community involvement and for cohort analysis.
+
+### How often have you felt explicitly welcome in the Rust community?
+
+Type: matrix
+
+Activities:
+
+- *Official* Rust community forums or chats (users.rust-lang.org, internals.rust-lang.org, the official Rust Discord, or the Rust Zulip)
+- *Unofficial* Rust community forums or chats (e.g., reddit.com/r/rust, Hacker News, the Rust *Community* Discord, etc.)
+- Attending a Rust conference
+- Attending a Rust meetup or local community event
+- Discussion (issues, pull requests, etc.) on a repository *inside* the rust-lang GitHub organization
+- Discussion (issues, pull requests, etc.) on a repository *outside* of the rust-lang GitHub organization
+
+Choices:
+
+- I've *often* felt welcome
+- I *sometimes* feel welcome
+- I *never* feel welcome
+- I've never participated in this activity
+
+> **justification**
+>
+> We'd like to know where people are feeling welcome and the degree to which they are feeling welcome.
+
+### How often have you felt *un*welcome in the Rust community?
+
+Type: matrix (optional)
+
+Activities:
+
+- *Official* Rust community forums or chats (users.rust-lang.org, internals.rust-lang.org, the official Rust Discord, or the Rust Zulip)
+- *Unofficial* Rust community forums or chats (e.g., reddit.com/r/rust, Hacker News, the Rust *Community* Discord, etc.)
+- Attending a Rust conference
+- Attending a Rust meetup or local community event
+- Discussion (issues, pull requests, etc.) on a repository *inside* the rust-lang GitHub organization
+- Discussion (issues, pull requests, etc.) on a repository *outside* of the rust-lang GitHub organization
+
+Choices:
+
+- I've *often* felt unwelcome
+- I *sometimes* feel unwelcome
+- I *never* feel unwelcome
+- I've never participated in this activity
+
+> **justification**
+>
+> We'd like to know where people are feeling unwelcome and the degree to which they are feeling unwelcome. This can 
+> help us better understand the free from responses that will come in the next question.
+
+### If you indicated that you did not feel welcome in the Rust community, are there any details about your experience that you would like to share with us?
+
+Type: free form (optional)
+
+> **justification**
+> 
+> More detail on the type of situations where people have felt unwelcome can let us better 
+> address these issues in the future.
+
+### Which of the following activities do you find helpful or effective for learning Rust or improving your Rust skills?
+
+Type: matrix (optional)
+
+Activities:
+
+- Reading books or other written material geared towards learning Rust
+- Watching videos, streams, etc. geared towards learning Rust
+- Attending an organized training session or course (in person or virtual)
+- Doing Rust coding exercises or challenges created to help learn Rust
+- Building a non-trivial project in Rust or contributing to an open source project
+
+Choices:
+
+- Very helpful
+- Somewhat helpful
+- Not helpful
+- I have no experience with this activity
+
+> **justification**
+>
+> We'd like to confirm what learning materials are popular with the community. This
+> combined with some cohort analysis can tell us about how particular subsections
+> of the community prefer to learn.
+
+## Rust at work
+
+### To what extent is Rust currently being used by your company?
+
+Type: select one
+
+- My company uses Rust for a large portion of production projects
+- My company uses Rust for a small portion of production projects
+- My company uses Rust only for non-production projects (e.g., tooling)
+- My company has actively experimented with Rust
+- My company has seriously considered, but not experimented with, using Rust
+- My company has not seriously considered Rust for any use
+- I am unsure whether my company has considered using or currently uses Rust
+- I don't work for a company or my company does not develop software of any kind [`NEXT`](#rust-in-education)
+
+> **justification**
+>
+> We want to establish how reliant companies are on Rust.
+
+### Approximately how many total developers does your company employ?
+
+**Note**: don't worry about being exact here! Go with you gut.
+
+Type: select one (optional)
+
+- Under 10
+- 11-49
+- 50-99
+- 100-500
+- 500-1,000
+- 1,000-10,000
+- Over 10,000
+
+> This question is not that interesting on its own, but it can be used as a sort of co-hort for understanding how answers 
+> change depending on the size of the development effort at a company.
+>
+> Previously this question used "employees" instead of "developers". It is more appropriate for us to ask about the amount
+> of developers at a company vs. the amount of people employed in total.
+
+### Is your company planning on hiring Rust developers in the next year?
+
+Type: select one (optional)
+
+- Yes
+- No
+- I don't know
+
+> This question assess hiring sentiment. Although there is intrinsic uncertainty, it is easy to answer and forward looking.
+> It will also be interesting to see what the demand for Rust skills from companies is over time.
+
+### In what technology domain(s) is Rust used at your company?
+
+If you've previously answered that your company is not actively using Rust, you can leave this question blank.
+
+Type: select all that apply (optional)
+
+- Audio programming
+- Blockchain
+- Cloud computing applications
+- Cloud computing infrastructure or utilities
+- Computer graphics
+- Data science
+- Desktop computer application frontend
+- Desktop computer or mobile phone libraries or services
+- Distributed systems
+- Embedded devices (with operating systems)
+- Embedded devices (bare metal)
+- HPC (High-performance [Super]Computing)
+- IoT (Internet of Things)
+- Machine learning
+- Mobile phone application frontend
+- Computer networking
+- Programming languages and related tools (including compilers, IDEs, standard libraries, etc.)
+- Robotics
+- Computer security
+- Scientific and/or numeric computing
+- Server-side or "backend" application
+- Simulation
+- Web application frontend
+- WebAssembly
+- Other (open response)
+
+> **justification**
+>
+> We want to known roughly what technology stacks are being most often used.
+>
+> This can be ambiguous and hard to answer. For example, if you're building an operating
+> system for a mobile phone, is that embedded, mobile, or something else?
+> We want to understand the "shape" of Rust usage, and this question tries to get at that
+> by allowing the respondent to select multiple answers.
+
+### Are you using Rust at work?
+
+Type: select one
+
+- Yes, for the majority of my coding
+- Yes, it's one of a number of languages I use and I use it regularly
+- Yes, but I only use it occasionally
+- No [`NEXT`](#rust-in-education)
+
+> **justification**
+>
+> We want to establish what percentage of those who could possibly use Rust in a professional setting
+> are using Rust in a professional setting. This is most interesting over time.
+> Answers to this question should be combined with whether the respondent has ever used Rust.
+
+
+### Rate how much the following statements are reasons which your team uses Rust at work
+
+Type: matrix (optional)
+
+Statements:
+
+- For its performance (i.e., speed, memory footprint, etc.) characteristics
+- We need precise control over exactly how our software runs
+- Its security and safety properties are important to us
+- It allows us to build relatively correct and bug free software
+- We find it enjoyable or fun to program in Rust
+- We already know Rust so it's our default choice
+- We find it easy to prototype with
+- We must interact with existing Rust code
+
+Rating:
+
+- Strongly agree
+- Agree
+- Neither agree nor disagree
+- Disagree
+- Strongly disagree
+
+> **justification**
+>
+> The Rust community and potential adopters of Rust have a lot of assumptions of why one would choose Rust for a project.
+> This question can help confirm or challenge our assumptions and see how they change over time.
+
+### Are there any additional reasons why your team uses Rust at work?
+
+Type: free form (optional)
+
+> **justification**
+>
+> Follow up to the question before to gain more insights.
+
+### Please rate your agreement with the following statements regarding your team's experience using Rust at work.
+
+Type: matrix (optional)
+
+Statements:
+
+- Using Rust has helped us achieve our goals
+- Adopting Rust has been challenging
+- Overall, adopting Rust has slowed down our team
+- Using Rust has been worth the cost of adoption
+- We're likely to use Rust again in the future
+
+Rating:
+
+- Agree
+- Neither agree nor disagree
+- Disagree
+
+> **justification**
+>
+> Future potential adopters may want to know how often other's have encountered success.
+
+### What about your usage of Rust has been challenging?
+
+Type: free form (optional)
+
+> **justification**
+>
+> This an opportunity to learn from adopters at companies what they struggle with when adopting Rust.
+
+## Rust in Education
+
+### Are you currently, or have you in the last year, taken a course or training which uses or teaches Rust?
+
+Type: select one
+
+- Yes
+- No [`NEXT`](#your-opinions-about-rust)
+
+> **justification**
+>
+> This question is primarily used to funnel respondents into the more specific questions about the kinds of educational activities they've been a part of.
+
+### Where is/was the course or activity taught?
+
+Type: select one (optional)
+
+- University or other tertiary institute
+- High school or secondary school
+- A course through an online "continuing education" provider (e.g., Udemy, Coursera, edX, LinkedIn Learning, etc.)
+- A bootcamp or other vocational-focused educational institute
+- A short training course offered through your employer or contracted by your employer
+
+> **justification**
+>
+> We want to know where Rust is being taught.
+
+### Which best describes your course or activity?
+
+Type: select one (optional)
+
+- A course teaching exclusively how to program in Rust
+- A course teaching how to program in Rust and other languages
+- A computer science course (e.g., operating systems, algorithms, etc.) course which uses Rust (and potentially other languages)
+- Other type of course where Rust was used
+
+> **justification**
+>
+> We want to know how Rust is being taught.
+
+### Is/was Rust mandated for your course or activity, or did you choose it yourself?
+
+Type: select one (optional)
+
+- Rust was mandated
+- I chose to use Rust
+
+> **justification**
+>
+> Together with the above question, we want to know how Rust is being taught.
+
+## Your opinions about Rust
+
+### What are your biggest worries for the future of Rust?
+
+Type: select all that apply (optional)
+
+- Not enough usage in industry
+- Too much interest from big companies
+- Not enough open source contributions to the ecosystem
+- Doesn't add a specific feature I want
+- Rust doesn't evolve quickly enough
+- Instability of the language
+- Superseded by an alternative
+- Becomes too complex
+- Tools and documentation are not accessible enough (e.g., due to language or incompatibility with screen readers)
+- Project governance does not scale to match the size/requirements of the community
+- Developers/maintainers of the language are not properly supported
+- I'm not worried
+- Other (open response)
+
+> **justification**
+>
+> Would be useful for leadership to understand the community's fears.
+
+### Please rate your agreement with the following statements about Rust.
+
+Type: matrix (optional)
+
+Statements:
+
+- Rust provides a real benefit over other programming languages
+- Rust is significantly more complicated to program in than other programming languages
+- Rust requires significantly more effort to learn than other programming languages
+- Rust code tends to contain significantly fewer bugs than equivalent code written in another programming language would have
+- Rust is risky to use in production
+- Rust makes me more productive
+- Rust is fun to use
+
+Rating:
+
+- Agree
+- Neither agree nor disagree
+- Disagree
+
+> **justification**
+>
+> There are several "truisms" about Rust that we'd like to get perspective on how true these are for users of Rust.
+>
+> Note that answers here can be subject to survivorship bias and so extra care should be taken with interpreting results.
+
+### In your opinion, how do you find the following aspects of Rust?
+
+Type: matrix (optional)
+
+Aspects:
+
+- Compile times
+- Binary size
+- Memory usage (i.e., how much RAM rustc uses when compiling)
+- Disk space usage (e.g., the size of target folder)
+- Bugs in the compiler (i.e., ICEs a.k.a. internal compiler errors, miscompilations, etc.)
+- Compiler error messages
+- IDE experience
+- Debugging experience
+- Available tools and support
+- Async programming
+- GUI development
+- Rust language and standard library documentation
+
+Options:
+
+- Great
+- Good enough
+- Could be better
+- Seriously lacking
+- Unsure
+
+> **justification**
+>
+> This question gathers data on the communities perceptions of certain aspects of Rust at this point in time.
+
+### In your opinion, have the following aspects of Rust gotten better or worse over the past year?
+
+Type: matrix (optional)
+
+Aspects:
+
+REPEAT
+
+Options:
+
+- Much better
+- Better  
+- Remained the same  
+- Worse
+- Much worse
+- Unsure
+
+> **justification**
+>
+> This question gathers data on the communities perceptions of certain aspects of Rust over the last year.
+
+### Do you agree with the following statements on Rust stability?
+
+Type: matrix (optional)
+
+Statements:
+
+- I can upgrade the *stable* compiler version without fear of my code failing to compile
+- I can upgrade the *nightly* compiler version without fear of my code failing to compile
+- I can upgrade the *stable* compiler version without fear of my code taking longer to compile
+- I can upgrade the *nightly* compiler version without fear of my code taking longer to compile
+- Upgrading to a new *stable* compiler version requires either no changes or extremely small & easy changes to my code
+- Upgrading to a new *nightly* compiler version requires either no changes or extremely small & easy changes to my code
+
+Rating:
+
+- Agree
+- Neither agree nor disagree
+- Disagree
+
+> **justification**
+>
+> When want to get an impression of how stable the compiler *feels*. Impressions are more important than hard numbers as
+> not all users define stability in the same way the compiler does. For example, experiencing compiler performance regressions
+> in a new version of the compiler isn't breaking official stability guarantees but it can feel just as painful as an
+> actual breaking change.
+
+### Do you agree with the following statements on Rust employment?
+
+Type: matrix (optional)
+
+Statements:
+
+- It is easy for qualified applicants to find jobs which use Rust for the majority of programming
+- Existing Rust jobs are attractive
+- Learning Rust provides me with skills that employers seek
+- I feel qualified to apply for at least some advertised Rust jobs
+
+Rating:
+
+- Agree
+- Neither agree nor disagree
+- Disagree
+
+> **justification**
+>
+> The flip side of the question asking whether the respondent's company plans on hiring Rust developers, we
+> want to know how respondents feel the level of demand for and quality of Rust jobs are.
+
+## About you
+
+See [who](./design/who.md).
+
+The following are primarily for cohort analysis, secondarily for understanding the shape of the community.
+
+For methodological purposes, the bulk of the demographics should be at the end of the survey (unless acting as filter/flow questions above).
+They're both easy to complete (beneficial at the end) and somewhat personal (but at this point folks are invested and we've built 'trust').
+Can also be problematic at start if we're asking all easy, personal questions and then get to the harder ones - easy to drop out.
+
+### Do you consider yourself a member of a group which is underrepresented or marginalized in technology?
+
+Please share only what you are comfortable sharing. This will help us better serve underrepresented and marginalized groups, better understand how well our outreach efforts are going, and more.
+
+Type: select one
+
+- Yes
+- No [`NEXT`](#are-you-a-full--or-part-time-student)
+- I prefer not to say [`NEXT`](#are-you-a-full--or-part-time-student)
+
+### Which of the following underrepresented or marginalized groups in technology do you consider yourself a part of?
+
+Please share only what you are comfortable sharing. This will help us better serve underrepresented and marginalized groups, better understand how well our outreach efforts are going, and more.
+
+Type: select all that apply (optional)
+
+- Cultural beliefs
+- Disabled or person with disability (including physical, mental, and other)
+- Educational background
+- Language
+- Lesbian, gay, bisexual, queer or otherwise non-heterosexual
+- Non-binary gender
+- Older or younger than the average developers I know
+- Political beliefs
+- Racial or ethnic minority
+- Religious beliefs
+- Trans
+- Woman or perceived as a woman
+- Other (open response)
+
+### Do you feel your belonging to an underrepresented or marginalized group in technology makes it difficult for you to participate in the Rust community?
+
+Type: select one (optional)
+
+- Often
+- Sometimes
+- Never
+
+### Are you a full- or part-time student?
+
+Type: select one
+
+- No
+- Yes, in secondary/high school
+- Yes, in a bachelor's/undergraduate program
+- Yes, in a master's program
+- Yes, in a doctorate program
+- Yes, in a vocational program
+- Yes, other
+
+> **justification**
+>
+> This will be important for cohort analysis. In particular, we want to
+> understand how students at different points in their education view
+> topics related to Rust.
+
+### Are you employed full- or part-time (including paid internships)?
+
+Type: select one
+
+- Yes
+- No [`NEXT`](#excluding-rust-what-is-your-experience-with-other-kinds-of-programming-languages)
+
+### Do you write or design software in your work?
+
+Type: select one
+
+- Yes, primarily as an individual contributor (i.e., non-manager)
+- I primarily manage others who do
+- No [`NEXT`](#excluding-rust-what-is-your-experience-with-other-kinds-of-programming-languages)
+
+### How long have you worked in software professionally?
+
+Type: select one (optional)
+
+- <= 1 year
+- 1 - 3 years
+- 3 - 5 years
+- 5 - 10 years
+- 10 - 20 years
+- > 20 years
+
+> **justification**
+>
+> For cohort analysis it is important to understand length of time in the software
+> industry as this can have an impact on perceptions.
+>
+> The ranges of years chosen are a best attempt at capturing different "stages" in a person's professional career.
+
+### Which category best describes your current employer's industry?
+
+Type: select all that apply (optional)
+
+- Advertising
+- Aerospace
+- Automotive
+- Business software
+- Consumer software
+- Consulting
+- Computer hardware
+- Defense
+- Energy
+- Education/Academia
+- Entertainment or Media
+- Finance
+- Gaming
+- Government
+- Healthcare
+- Manufacturing
+- Music
+- Railway
+- Research & Development
+- Retail
+- Telecommunications
+- Transportation
+- I'm not employed
+- Other (open response)
+
+> **justification**
+>
+> We want to see what industries have what representation in the Rust community.
+> While it's impossible to be precise here, we want to get a general idea.
+> This list is largely adopted from this [Wikipedia article](https://en.wikipedia.org/wiki/Outline_of_industry).
+
+### Which categories best describes the tech domain(s) you currently write or design software in?
+
+Type: select all that apply (optional)
+
+- Audio programming
+- Blockchain
+- Cloud computing applications
+- Cloud computing infrastructure or utilities
+- Computer graphics
+- Data science
+- Desktop computer application frontend
+- Desktop computer or mobile phone libraries or services
+- Distributed systems
+- Embedded devices (with operating systems)
+- Embedded devices (bare metal)
+- HPC (High-performance [Super]Computing)
+- IoT (Internet of Things)
+- Machine learning
+- Mobile phone application frontend
+- Computer networking
+- Programming languages and related tools (including compilers, IDEs, standard libraries, etc.)
+- Robotics
+- Computer security
+- Scientific and/or numeric computing
+- Server-side or "backend" application
+- Simulation
+- Web application frontend
+- WebAssembly
+- Other (open response)
+
+> **justification**
+>
+> We want to see generally what tech areas respondents work in. In addition to general categories,
+> we include some technology categories that are known to be popular in the Rust community.
+> This can help us get more insight into what respondents are working on. For instance, if a respondent
+> answers their employer works in automotive but they are working on mobile phone applications and not 
+> embedded devices, we might conclude different things than if they are working on embedded devices.
+
+### Excluding Rust, what is your experience with other kinds of programming languages?
+
+Type: matrix (optional)
+
+Languages:
+
+- Assembly language (of any variety)
+- Languages with manual memory management (e.g., C, C++, Objective-C without ARC)
+- Statically typed object oriented languages with garbage collection (e.g., Java, C#, Go)
+- Statically typed functional programming languages (e.g., Haskell, ML)
+- Dynamically typed functional programming languages (e.g., Lisp, Clojure, Elixir)
+- Statically typed languages with newer expressive type systems (e.g., Swift, Kotlin, Scala)
+- Dynamically typed languages (e.g., Javascript, Ruby, Python, PHP, Perl)
+
+Experience:
+
+- I've never used nor am I familiar with any language in this category
+- I have a basic familiarity with at least one language in this category
+- I am comfortable using at least one language in this category
+- I am an expert in at least one language in this category
+
+> **justification**
+>
+> For cohort analysis it is interesting to know what other language "families"
+> respondents are familiar with. It is more illustrative which types of languages
+> respondents are familiar with than the specific language.
+
+### How long have you been programming (in any language, for any reason)?
+
+Type: select one (optional)
+
+- < 1 year
+- < 3 years
+- < 5 years
+- < 10 year
+- > 10 years
+
+### Where do you live?
+
+Type: select one (optional)
+
+- *all UN member states*
+- *two observer states (Vatican City and Palestine)*
+- Other
+
+> **justification**
+>
+> We'd like to get a geographic understanding of where the community is. The form of the question allows us to be fairly precise about this
+> though there will still be some challenges (e.g., someone who lives in East Russia has similar timezones to East Asia not West Russia).
+
+### As you selected "Other" from the list of countries above, please enter your territory of residence below:
+
+Type: free form (optional)
+
+### In what ways are you comfortable communicating about technical topics in English?
+
+Type: select all that apply (optional)
+
+- I feel comfortable and capable of having a spoken technical conversation in English
+- I feel comfortable and capable of having a written technical conversation in English
+- I feel comfortable and capable of reading technical documentation in English
+- I feel comfortable and capable of consuming a technical talk (e.g., at a conference or meetup) in English
+- I feel comfortable and capable of consuming a written technical educational material (e.g., technical books, blog posts, etc.) in English
+
+> **justification**
+>
+> We want to understand self reported feeling of comfort and capability of communication
+> of English since a large portion of the Rust community is and likely will always be in English.
+
+### What is/are your preferred language(s) for technical communication?
+
+**IMPORTANT**: Your answer should reflect your **preference** and **not** what you are capable of communicating in. For example, if you feel comfortable and capable of consuming technical communication in both English and Korean, but you always prefer Korean, you should *only* answer Korean as that is your preference.
+
+Type: select all that apply (optional)
+
+- Chinese
+- Spanish
+- English
+- Hindi
+- Bengali
+- Portuguese
+- Russian
+- Japanese
+- Turkish
+- Korean
+- French
+- German
+- Vietnamese
+- Urdu
+- Other (open response)
+
+> **justification**
+>
+> We want to understand *preference* of technical communication and how that differs
+> from their abilities to consume technical communication in English.
+> The languages selected are based on all national languages that are members of
+> the top 20 most spoken languages in the world.
+
+## Anything else?
+
+### Is there anything else you'd like to tell us?
+
+Type: free form (optional)
+
+> **justification**
+>
+> While it's unlikely we'll receive any one piece of feedback from this question that will prove to be super useful, 
+> having it in the survey can still be useful. It can help us decide on new questions or perspectives that we want to
+> try to capture in future surveys. It also gives respondents a place to give thanks or share a particular opinion they
+> hold which can be useful in and of itself.


### PR DESCRIPTION
By collecting existing surveys in this repo, we can use them to animate discussion and populate our own survey.
The rust survey also has some `.md` files explaining the rationale behind these questions, but most of the important bits are synthesized in the **justification** sections of this `.md` document.